### PR TITLE
OS interoperability

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,13 +7,17 @@ branches:
   only:
     - master
 
+os:
+  - linux
+  - osx
+
 env:
   - GO111MODULE=on
 
 before_script:
-  - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
-  - chmod +x ./cc-test-reporter
-  - ./cc-test-reporter before-build
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then chmod +x ./cc-test-reporter; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ./cc-test-reporter before-build; fi
 
 install:
   - make deps
@@ -22,4 +26,4 @@ script:
   - make test
 
 after_script:
-  - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT; fi

--- a/tag/tag.go
+++ b/tag/tag.go
@@ -76,7 +76,13 @@ func Write(file string, set Set) error {
 }
 
 func isAttributeNotFoundError(err error) bool {
-	return strings.Contains(err.Error(), "attribute not found")
+	for _, msg := range []string{"attribute not found", "no data available"} {
+		if strings.Contains(err.Error(), msg) {
+			return true
+		}
+	}
+
+	return false
 }
 
 func nameAndClassifier(s string) (string, string, bool) {

--- a/tag/tag.go
+++ b/tag/tag.go
@@ -6,7 +6,7 @@ import (
 )
 
 // XattrName holds the extended attribute name the tags are stored with.
-const XattrName = "bilocation.corvus-ch.name/v1/tags"
+const XattrName = "user.bilocation.corvus-ch.name/v1/tags"
 
 // Config provides the input for tag operations.
 type Config interface {

--- a/tag/tag_test.go
+++ b/tag/tag_test.go
@@ -1,5 +1,3 @@
-// +build integration
-
 package tag_test
 
 import (


### PR DESCRIPTION
Enable tests for Linux and OS X and prefix name of extended attribute with `user.` namespace in order to prevent failure on Linux.