### PR TITLE
feat: Command to list tags of a file

### DIFF
--- a/cmd/inspect.go
+++ b/cmd/inspect.go
@@ -1,0 +1,32 @@
+package cmd
+
+import (
+	"strings"
+
+	"github.com/corvus-ch/bilocation/tag"
+	"gopkg.in/alecthomas/kingpin.v2"
+)
+
+// Inspect registers the inspect sub command to the application.
+func Inspect(app *kingpin.Application, cfg *config) {
+	c := app.Command("inspect", "show the tags of a file")
+	c.Action(func(_ *kingpin.ParseContext) error {
+		set, err := tag.Read(cfg.Path())
+		if err != nil {
+			return err
+		}
+
+		for name := range set {
+			c := set.Get(name)
+			if len(c) > 0 {
+				cfg.Log().Infof("%s (%s)", name, strings.Join(c, ", "))
+			} else {
+				cfg.Log().Info(name)
+			}
+		}
+		return nil
+	})
+	c.Arg("file", "path to the file").
+		Required().
+		ExistingFileVar(&cfg.path)
+}

--- a/fixtures/help.golden
+++ b/fixtures/help.golden
@@ -16,6 +16,9 @@ ERROR
 ERROR   untag <file> <tag>...
 ERROR     removes a tag from a file
 ERROR 
+ERROR   inspect <file>
+ERROR     show the tags of a file
+ERROR 
 ERROR   search [<flags>] <query>
 ERROR     search for files wit a given tag
 ERROR 

--- a/main.go
+++ b/main.go
@@ -28,6 +28,7 @@ func App(log logr.Logger) *kingpin.Application {
 	cfg := cmd.NewConfig(log)
 	cmd.Tag(app, cfg)
 	cmd.Untag(app, cfg)
+	cmd.Inspect(app, cfg)
 	cmd.Search(app, cfg)
 	cmd.Summary(app, cfg)
 


### PR DESCRIPTION
Added the sub command `inspect` which prints out the tags of a single file.